### PR TITLE
Send promise output via `res.send` when provided.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ router.use('/url', function (req, res, next) {
 });
 ```
 
+The resolved value is automatically sent through the response via `res.send`.
+```javascript
+router = require('express-promise-router')();
+
+// outputs '{"foo":"bar"}' JSON data
+router.use('/url', function (req, res, next) {
+    return Promise.resolve({ foo: 'bar' });
+});
+```
+
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).

--- a/lib/express-promise-router.js
+++ b/lib/express-promise-router.js
@@ -23,7 +23,8 @@ var wrapHandler = function (handler) {
 
         var promises = [nextPromise];
 
-        var next = args.slice(-1)[0];
+        var next = args[args.length - 1];
+        var res = args[args.length - 2];
         var ret = handler.apply(null, args);
 
         if (isPromise(ret)) {
@@ -36,6 +37,8 @@ var wrapHandler = function (handler) {
                     next();
                 } else if (d === 'route') {
                     next('route');
+                } else if (d !== undefined) {
+                    res.send(d);
                 }
             }, function (err) {
                 if (!err) {

--- a/test/express-promise-router.test.js
+++ b/test/express-promise-router.test.js
@@ -118,13 +118,11 @@ describe('express-promise-router', function () {
 
         router.get('/foo', function (req, res) {
             return new Promise(function (resolve) {
-                res.send();
                 delay(resolve, 'something');
             });
         });
         router.get('/bar', function (req, res) {
             return new Promise(function (resolve) {
-                res.send();
                 delay(resolve, {});
             });
         });
@@ -334,6 +332,20 @@ describe('express-promise-router', function () {
             return GET('/foo/1');
         }).then(function (res) {
             assert.equal(res.body, 'done');
+        }).nodeify(done);
+    });
+
+    it('should output resolved promise value', function (done) {
+        router.use('/foo', function (req, res) {
+            return new Promise(function(resolve) {
+                delay(resolve, { foo: 'bar' });
+            });
+        });
+
+        bootstrap(router).then(function () {
+            return GET('/foo');
+        }).then(function (res) {
+            assert.equal(res.body, '{"foo":"bar"}');
         }).nodeify(done);
     });
 


### PR DESCRIPTION
Being able to return data from the request is kind of a major convenience for people with ORM libraries that return promises like sequelize. Ideally there would be a nice way to return status code, headers and the like but at least this gets the ball rolling.
