### PR TITLE
fix bug when the route is a Null string

### DIFF
--- a/lib/express-promise-router.js
+++ b/lib/express-promise-router.js
@@ -69,7 +69,7 @@ var wrapMethods = function(instanceToWrap, isRoute) {
             // Manipulating arguments directly is discouraged
             var args = new Array(arguments.length);
             for (var i = 0; i < arguments.length; ++i) {
-                args[i] = arguments[i];
+                args[i] = arguments[i] || '/';
             }
 
             // Grab the first parameter out in case it's a route or array of routes.


### PR DESCRIPTION
I got an error message when I use like this:

```js
// With express-promise-router
var router = require('express-promise-router')();

router.use('', function (req, res) {
    return Promise.reject();
})
```

this is the error message:

```
/express-promise-router/lib/express-promise-router.js:81
                ((Array.isArray(args[0]) && 'string' === typeof args[0][0]) || args[0][0] instanceof RegExp)
                                                                                      ^

TypeError: Cannot read property '0' of undefined
```

Yeah, the original url is a Null string, though it‘s not standard.

