### PR TITLE
Remove express type peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "methods": "^1.0.0"
   },
   "peerDependencies": {
-    "@types/express": "^4.0.0",
     "express": "4.x"
   },
   "devDependencies": {


### PR DESCRIPTION
As a side effect of #47 we introduced `@types/express` as a peer dependency, which caused friction for a significant amount of users.

This PR will undo that change as quick fix.