### PR TITLE
Fix typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,5 +3,5 @@ declare module 'express-promise-router' {
 
     function PromiseRouter(options?: RouterOptions): Router;
 
-    export default PromiseRouter;
+    export = PromiseRouter;
 }

--- a/test/test-resources/typescript-base-case.ts
+++ b/test/test-resources/typescript-base-case.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../index.d.ts"/>
-import * as express from 'express';
-import Router from '../../lib/express-promise-router.js';
+import express = require('express');
+import Router = require('../../lib/express-promise-router.js');
 const router = Router();
 
 router.get('/', function(req, res) {


### PR DESCRIPTION
This is a duplicate of #53 but with the test case adjusted.

Using ES6 module import syntax doesn't make sense for express nor express-promise-router because they're both commonjs and have no named export with the name `default`. This can be worked around using babel and webpack but `tsc` out of the box assumes ES6 default imports always target ES6 modules (or compatible commonjs modules).

The [correct way to import commonjs modules](https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require) in TypeScript is to use the TypeScript-specific `import = require` syntax:

> TypeScript supports `export =` to model the traditional CommonJS and AMD workflow.
> [..]
> When exporting a module using `export =`, TypeScript-specific `import module = require("module")` must be used to import the module.

This PR corrects the test case to use the commonjs import and adjusts the definition file to correctly type the export as a commonjs module.

Considering the issue has been open since January and the module is effectively unusable with TypeScript without either monkeypatching the type definition locally or overriding the import type as `any`, I'd suggest either merging this ASAP once it's green or merging and releasing the "default export" branch which would make express-promise-router ES6 compatible as far as TypeScript is concerned.