### PR TITLE
Make possible to patch the main app router

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ router.use('/url', function (req, res, next) {
 });
 ```
 
+Finally, you can install this router as the top-level router on the app object. All the `app`
+calls are transparently wrapped. The caveat is that creating additional routers should still
+use this package explicitly, instead of `express.Router()`.
+
+```javascript
+var PromiseRouter = require('express-promise-router');
+var app = express();
+PromiseRouter.wrapApp(app);
+
+app.use('/url', function (req, res) {
+    return Promise.reject();
+})
+
+var router = PromiseRouter()
+app.use('/path', router)
+```
 
 ## Contributing
 Add unit tests for any new or changed functionality.

--- a/lib/express-promise-router.js
+++ b/lib/express-promise-router.js
@@ -98,8 +98,8 @@ var wrapMethods = function(instanceToWrap, isRoute) {
     return instanceToWrap;
 };
 
-var PromiseRouter = function(path) {
-    var me = wrapMethods(new Router(path));
+function wrapRouter(router) {
+    var me = wrapMethods(router);
 
     var __route = me.route;
     me.route = function(path) {
@@ -107,7 +107,17 @@ var PromiseRouter = function(path) {
     };
 
     return me;
-};
+}
+
+function wrapApp(app) {
+    app.lazyrouter();
+    app._router = wrapRouter(app._router);
+}
+
+function PromiseRouter(path) {
+    return wrapRouter(new Router(path));
+}
 
 PromiseRouter.default = PromiseRouter;
+PromiseRouter.wrapApp = wrapApp;
 module.exports = PromiseRouter;

--- a/lib/express-promise-router.js
+++ b/lib/express-promise-router.js
@@ -63,8 +63,7 @@ var wrapMethods = function(instanceToWrap, isRoute) {
     var methods = require('methods').concat(toConcat);
 
     methods.forEach(function(method) {
-        var original = '__' + method;
-        instanceToWrap[original] = instanceToWrap[method];
+        var original = instanceToWrap[method];
         instanceToWrap[method] = function() {
             // Manipulating arguments directly is discouraged
             var args = new Array(arguments.length);
@@ -92,7 +91,7 @@ var wrapMethods = function(instanceToWrap, isRoute) {
                 args.unshift(first);
             }
 
-            return instanceToWrap[original].apply(this, args);
+            return original.apply(this, args);
         };
     });
 
@@ -102,9 +101,9 @@ var wrapMethods = function(instanceToWrap, isRoute) {
 var PromiseRouter = function(path) {
     var me = wrapMethods(new Router(path));
 
-    me.__route = me.route;
+    var __route = me.route;
     me.route = function(path) {
-        return wrapMethods(me.__route(path), true);
+        return wrapMethods(__route.call(me, path), true);
     };
 
     return me;

--- a/test/express-promise-router.app.test.js
+++ b/test/express-promise-router.app.test.js
@@ -1,0 +1,398 @@
+'use strict';
+
+var assert = require('chai').assert;
+var sinon = require('sinon');
+var express = require('express');
+var GET = require('./util/http-utils').GET;
+
+var delay = function(method, payload) {
+    setTimeout(function() {
+        method(payload);
+    }, 10);
+};
+
+var PromiseRouter = require('../lib/express-promise-router.js');
+
+describe('express-promise-router', function() {
+    var app;
+    var serverListening;
+    var server;
+
+    var bootstrap = function() {
+        if (serverListening) {
+            throw 'already bootstrapped';
+        }
+
+        serverListening = new Promise(function(resolve, reject) {
+            server = app.listen(12345, function(err) {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve();
+                }
+            });
+        });
+
+        return serverListening;
+    };
+
+    beforeEach(function() {
+        app = express();
+        PromiseRouter.wrapApp(app);
+    });
+
+    afterEach(function() {
+        if (serverListening) {
+            return serverListening.then(function() {
+                server.close();
+                app = undefined;
+                server = undefined;
+                serverListening = undefined;
+            });
+        }
+    });
+
+    it('should call next with an error when a returned promise is rejected', function() {
+        var callback = sinon.spy();
+
+        app.use('/foo', function() {
+            return new Promise(function(resolve, reject) {
+                delay(reject, 'some error');
+            });
+        });
+        app.use(function(err, req, res, next) {
+            assert.equal('some error', err);
+            callback();
+            res.send();
+        });
+
+        return bootstrap()
+            .then(function() {
+                return GET('/foo');
+            })
+            .then(function() {
+                assert(callback.calledOnce);
+            });
+    });
+
+    it('should call next without an error when a returned promise is resolved with "next"', function() {
+        var errorCallback = sinon.spy();
+        var nextCallback = sinon.spy();
+
+        app.use('/foo', function() {
+            return new Promise(function(resolve) {
+                delay(resolve, 'next');
+            });
+        });
+        app.use('/foo', function(req, res) {
+            nextCallback();
+            res.send();
+        });
+        app.use(function(err, req, res, next) {
+            errorCallback();
+            next();
+        });
+
+        return bootstrap()
+            .then(function() {
+                return GET('/foo');
+            })
+            .then(function() {
+                assert(errorCallback.notCalled);
+                assert(nextCallback.calledOnce);
+            });
+    });
+
+    it('should not call next when a returned promise is resolved with anything other than "route" or "next"', function() {
+        var callback = sinon.spy();
+
+        app.get('/foo', function(req, res) {
+            return new Promise(function(resolve) {
+                res.send();
+                delay(resolve, 'something');
+            });
+        });
+        app.get('/bar', function(req, res) {
+            return new Promise(function(resolve) {
+                res.send();
+                delay(resolve, {});
+            });
+        });
+        app.use(function(req, res) {
+            callback();
+            res.send(500);
+        });
+
+        return bootstrap()
+            .then(function() {
+                return GET('/foo');
+            })
+            .then(function() {
+                assert(callback.notCalled);
+                return GET('/bar');
+            })
+            .then(function() {
+                assert(callback.notCalled);
+            });
+    });
+
+    it('should move to the next middleware when next is called without an error', function() {
+        var callback = sinon.spy();
+
+        app.use('/foo', function(req, res, next) {
+            next();
+        });
+        app.use('/foo', function(req, res, next) {
+            callback();
+            res.send();
+        });
+
+        return bootstrap()
+            .then(function() {
+                return GET('/foo');
+            })
+            .then(function() {
+                assert(callback.calledOnce);
+            });
+    });
+
+    it('should move to the next error handler when next is called with an error', function() {
+        var callback = sinon.spy();
+        var errorCallback = sinon.spy();
+
+        app.use('/foo', function(req, res, next) {
+            next('an error');
+        });
+        app.use('/foo', function(req, res, next) {
+            callback();
+            next();
+        });
+        app.use(function(err, req, res, next) {
+            assert.equal('an error', err);
+            errorCallback();
+            res.send();
+        });
+
+        return bootstrap()
+            .then(function() {
+                return GET('/foo');
+            })
+            .then(function() {
+                assert(errorCallback.calledOnce);
+                assert(callback.notCalled);
+            });
+    });
+
+    it('should call chained handlers in the correct order', function() {
+        var fn2 = sinon.spy(function(req, res) {
+            res.send();
+        });
+        var fn1 = sinon.spy(function() {
+            assert(fn2.notCalled);
+            return Promise.resolve('next');
+        });
+
+        app.get('/foo', fn1, fn2);
+
+        return bootstrap().then(function() {
+            return GET('/foo');
+        });
+    });
+
+    it('should correctly call an array of handlers', function() {
+        var fn2 = sinon.spy(function(req, res) {
+            res.send();
+        });
+        var fn1 = sinon.spy(function() {
+            assert(fn2.notCalled);
+            return Promise.resolve('next');
+        });
+
+        app.get('/foo', [[fn1], [fn2]]);
+
+        return bootstrap().then(function() {
+            return GET('/foo');
+        });
+    });
+
+    it('should call next("route") if a returned promise is resolved with "route"', function() {
+        var fn1 = function() {
+            return Promise.resolve('route');
+        };
+        var fn2 = function() {
+            assert.fail();
+        };
+
+        app.get('/foo', fn1, fn2);
+        app.get('/foo', function(req, res) {
+            res.send();
+        });
+
+        return bootstrap().then(function() {
+            return GET('/foo');
+        });
+    });
+
+    it('should bind to RegExp routes', function() {
+        var fn1 = function(req, res) {
+            res.send();
+        };
+
+        app.get(/^\/foo/, fn1);
+
+        return bootstrap().then(function() {
+            return GET('/foo');
+        });
+    });
+
+    it('multiple calls to handlers that have used "next" should not interfere with each other', function() {
+        var fn = sinon.spy(function(req, res, next) {
+            if (fn.calledOnce) {
+                next('error');
+            } else {
+                setTimeout(function() {
+                    res.status(200).send('ok');
+                }, 15);
+            }
+        });
+        var errHandler = function(err, req, res, next) {
+            if (err === 'error') {
+                res.send('fail');
+            } else {
+                next(err);
+            }
+        };
+
+        app.get('/foo', fn, errHandler);
+
+        return bootstrap()
+            .then(function() {
+                return GET('/foo');
+            })
+            .then(function(res) {
+                assert.equal(res.body, 'fail');
+                return GET('/foo');
+            })
+            .then(function(res) {
+                assert.equal(res.body, 'ok');
+            });
+    });
+
+    it('calls next if next is called even if the handler returns a promise', function() {
+        var fn = function(req, res, next) {
+            next();
+            return new Promise(function(resolve, reject) {});
+        };
+        var fn2 = function(req, res) {
+            res.send('ok');
+        };
+        var errHandler = function(err, req, res, next) {
+            res.send('error');
+        };
+
+        app.get('/foo', fn, fn2, errHandler);
+
+        return bootstrap()
+            .then(function() {
+                return GET('/foo');
+            })
+            .then(function(res) {
+                assert.equal(res.body, 'ok');
+            });
+    });
+
+    it('calls next with an error if the returned promise is rejected with no reason', function() {
+        var fn = function() {
+            return new Promise(function(resolve, reject) {
+                delay(reject, null);
+            });
+        };
+        var errHandler = function(err, req, res, next) {
+            res.send('error');
+        };
+
+        app.get('/foo', fn, errHandler);
+
+        return bootstrap()
+            .then(function() {
+                return GET('/foo');
+            })
+            .then(function(res) {
+                assert.equal(res.body, 'error');
+            });
+    });
+
+    it('should handle resolved promises returned in req.param() calls', function() {
+        app.param('id', function() {
+            return new Promise(function(resolve) {
+                delay(resolve, 'next');
+            });
+        });
+        app.use('/foo/:id', function(req, res) {
+            res.send('done');
+        });
+
+        return bootstrap()
+            .then(function() {
+                return GET('/foo/1');
+            })
+            .then(function(res) {
+                assert.equal(res.body, 'done');
+            });
+    });
+
+    it('should call next with unresolved promises returned in req.param() calls', function() {
+        var assertOutput = 'error in param';
+
+        app.param('id', function(req, res, next, id) {
+            return new Promise(function(resolve, reject) {
+                delay(reject, assertOutput);
+            });
+        });
+
+        var fn = function(req, res) {
+            res.send('done');
+        };
+
+        var errHandler = function(err, req, res, next) {
+            res.send(err);
+        };
+
+        app.use('/foo/:id', fn);
+
+        app.use(errHandler);
+
+        return bootstrap()
+            .then(function() {
+                return GET('/foo/1');
+            })
+            .then(function(res) {
+                assert.equal(res.body, assertOutput);
+            });
+    });
+
+    it('support array in routes values', function() {
+        app.use(['/', '/foo/:bar'], function(req, res) {
+            res.send('done');
+        });
+
+        return bootstrap()
+            .then(function() {
+                return GET('/');
+            })
+            .then(function(res) {
+                assert.equal(res.body, 'done');
+
+                return GET('/foo/1');
+            })
+            .then(function(res) {
+                assert.equal(res.body, 'done');
+            });
+    });
+
+    it('should throw sensible errors when handler is not a function', function() {
+        assert.throws(function() {
+            app.use('/foo/:id', null);
+        }, /callback/);
+    });
+});


### PR DESCRIPTION
This is a way to apply the promise-router to the top-level express app object. Instead of exposing the wrapping function, it seemed a good idea to implement a dedicated one that would patch an `app` correctly.

I couldn't resist removing the `__method` properties that store the original, unwrapped ones. The same functionality is perfectly achievable with closures and I can't think of a benefit of having them available on the public API. That said, I won't insist on having this change included.