### PR TITLE
Fix semver range for peer dependency of express

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "methods": "^1.0.0"
   },
   "peerDependencies": {
-    "express": "4.x"
+    "express": "^4.0.0"
   },
   "devDependencies": {
     "@types/express": "^4.11.0",


### PR DESCRIPTION
Using caret and allowing ^4.0.0 vs 4.x which requires implementing application to list their express versions with 4.x specifically.