### PR TITLE
Propagate handler name to wrapper

### DIFF
--- a/.changeset/fifty-plums-applaud.md
+++ b/.changeset/fifty-plums-applaud.md
@@ -1,0 +1,5 @@
+---
+"express-promise-router": minor
+---
+
+The handler function now uses the name of the original (wrapped) handler as its name to aid in debugging and tracing.

--- a/lib/express-promise-router.js
+++ b/lib/express-promise-router.js
@@ -49,6 +49,7 @@ var wrapHandler = function (handler) {
   };
 
   if (handler.length === 4) {
+    // Preserve the original handler function name. See #146.
     const wrapperObj = {
       [handler.name]: function (err, req, res, next) {
         handleReturn([err, req, res, next]);
@@ -57,6 +58,7 @@ var wrapHandler = function (handler) {
     return wrapperObj[handler.name];
   }
 
+  // Preserve the original handler function name. See #146.
   const wrapperObj = {
     [handler.name]: function (req, res, next) {
       handleReturn([req, res, next]);

--- a/lib/express-promise-router.js
+++ b/lib/express-promise-router.js
@@ -49,14 +49,20 @@ var wrapHandler = function (handler) {
   };
 
   if (handler.length === 4) {
-    return function (err, req, res, next) {
-      handleReturn([err, req, res, next]);
+    const wrapperObj = {
+      [handler.name]: function (err, req, res, next) {
+        handleReturn([err, req, res, next]);
+      },
     };
+    return wrapperObj[handler.name];
   }
 
-  return function (req, res, next) {
-    handleReturn([req, res, next]);
+  const wrapperObj = {
+    [handler.name]: function (req, res, next) {
+      handleReturn([req, res, next]);
+    },
   };
+  return wrapperObj[handler.name];
 };
 
 var wrapMethods = function (instanceToWrap, isRoute) {

--- a/test/tracing.test.js
+++ b/test/tracing.test.js
@@ -25,4 +25,12 @@ describe("function name", function () {
     assert.equal(router.stack[0].handle.name, "actualErrorHandler");
     assert.equal(router.stack[0].name, "actualErrorHandler");
   });
+
+  it("empty name for anonymous middleware handler", function () {
+    const router = Router();
+    router.use((req, res, next) => {});
+
+    assert.equal(router.stack[0].handle.name, "");
+    assert.equal(router.stack[0].name, "<anonymous>");
+  });
 });

--- a/test/tracing.test.js
+++ b/test/tracing.test.js
@@ -1,0 +1,28 @@
+const Router = require("../lib/express-promise-router");
+const assert = require("chai").assert;
+
+describe("function name", function () {
+  it("uses the wrapped handler's name in a route handler", function () {
+    const router = Router();
+    router.get("/test-route", function actualHandler() {});
+
+    assert.equal(router.stack[0].route.stack[0].handle.name, "actualHandler");
+    assert.equal(router.stack[0].route.stack[0].name, "actualHandler");
+  });
+
+  it("uses the wrapped handler's name in a middleware handler", function () {
+    const router = Router();
+    router.use(function actualHandler(req, res, next) {});
+
+    assert.equal(router.stack[0].handle.name, "actualHandler");
+    assert.equal(router.stack[0].name, "actualHandler");
+  });
+
+  it("uses the wrapped handler's name in an error middleware", function () {
+    const router = Router();
+    router.use(function actualErrorHandler(err, req, res, next) {});
+
+    assert.equal(router.stack[0].handle.name, "actualErrorHandler");
+    assert.equal(router.stack[0].name, "actualErrorHandler");
+  });
+});


### PR DESCRIPTION
We do this to improve debuggability and tracing support.
Fixes #146.

Hey @mwinstanley, please check if this solves your problem.