### PR TITLE
fix: ensure nested routes includes handler context

### DIFF
--- a/.changeset/tiny-olives-yell.md
+++ b/.changeset/tiny-olives-yell.md
@@ -1,0 +1,5 @@
+---
+"express-promise-router": minor
+---
+
+Router handler functions now include all additional properties to aid discoverability of registered routes.

--- a/lib/express-promise-router.js
+++ b/lib/express-promise-router.js
@@ -64,6 +64,12 @@ var wrapHandler = function (handler) {
       handleReturn([req, res, next]);
     },
   };
+
+  // Correctly include router handler context. See #306.
+  if (handler.name === "router") {
+    Object.assign(wrapperObj[handler.name], handler);
+  }
+
   return wrapperObj[handler.name];
 };
 

--- a/test/express-promise-router.nested-route.test.js
+++ b/test/express-promise-router.nested-route.test.js
@@ -1,0 +1,18 @@
+"use strict";
+
+var assert = require("chai").assert;
+var sinon = require("sinon");
+
+var PromiseRouter = require("../lib/express-promise-router.js");
+
+describe("Nested routes..", () => {
+  it("Should correctly provide handle contexts when nested routes are created", () => {
+    const router = PromiseRouter();
+    const subRouter = PromiseRouter();
+
+    subRouter.get("/users", (req, res) => res.send("ok"));
+    router.use("/api", subRouter);
+
+    assert.exists(router.stack[0].handle.stack);
+  });
+});


### PR DESCRIPTION
Ensures router handler context is included. This improves functionality of packages like `express-list-endpoints` and others.

Fixes #306 
