### PR TITLE
Fix typo in documentation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ const router = Router();
 Using `async` / `await` can dramatically improve code readability.
 
 ```javascript
-router.get('/url', async (req, res) {
+router.get('/url', async function (req, res) {
     const user = await User.fetch(req.user.id);
 
     if (user.permission !== "ADMIN") {


### PR DESCRIPTION
Supersedes #235 due to inactivity

Co-authored-by: Richard Keller <richard.be.jamin@gmail.com>