### PR TITLE
Correctly set context of nested routes

### DIFF
--- a/.changeset/slimy-emus-cover.md
+++ b/.changeset/slimy-emus-cover.md
@@ -1,0 +1,5 @@
+---
+"express-promise-router": patch
+---
+
+Fixes a bug introduced when setting the handler context on nested routes in which New Relic would incorrectly log API transaction names

--- a/lib/express-promise-router.js
+++ b/lib/express-promise-router.js
@@ -48,6 +48,12 @@ const wrapHandler = function (handler) {
     );
   };
 
+  // If the handler is itself a router, return it directly
+  // in order to properly handle nested routes.
+  if (handler.name === 'router') {
+    return handler;
+  }
+
   if (handler.length === 4) {
     // Preserve the original handler function name. See #146.
     const wrapperObj = {
@@ -64,11 +70,6 @@ const wrapHandler = function (handler) {
       handleReturn([req, res, next]);
     },
   };
-
-  // Correctly include router handler context. See #306.
-  if (handler.name === "router") {
-    Object.assign(wrapperObj[handler.name], handler);
-  }
 
   return wrapperObj[handler.name];
 };


### PR DESCRIPTION
PR #307 introduced a bug in which New Relic would no longer correctly name transactions for nested routes.

For example, in the following type of scenario:
```
const router = PromiseRouter();
const subRouter = PromiseRouter();

subRouter.get("/users", (req, res) => res.send("ok"));
router.use("/api", subRouter);
```
New Relic would incorrectly name the transaction `/users` instead of the expected `/api/users`.

This change maintains backward compatibility with existing nested route tests.