### PR TITLE
Assign all own properties back to wrapper objects

### DIFF
--- a/.changeset/chatty-dancers-teach.md
+++ b/.changeset/chatty-dancers-teach.md
@@ -1,0 +1,5 @@
+---
+"express-promise-router": patch
+---
+
+Copy own properties to all wrappers. This ensures all metadata is available to other libraries that might introspect routes.

--- a/lib/express-promise-router.js
+++ b/lib/express-promise-router.js
@@ -55,6 +55,7 @@ const wrapHandler = function (handler) {
         handleReturn([err, req, res, next]);
       },
     };
+    Object.assign(wrapperObj[handler.name], handler);
     return wrapperObj[handler.name];
   }
 
@@ -66,9 +67,7 @@ const wrapHandler = function (handler) {
   };
 
   // Correctly include router handler context. See #306.
-  if (handler.name === "router") {
-    Object.assign(wrapperObj[handler.name], handler);
-  }
+  Object.assign(wrapperObj[handler.name], handler);
 
   return wrapperObj[handler.name];
 };
@@ -123,6 +122,7 @@ const PromiseRouter = function (path) {
   me.route = function (path) {
     return wrapMethods(me.__route(path), true);
   };
+  Object.assign(me.route, me.__route);
 
   return me;
 };


### PR DESCRIPTION
Ensures all metadata is present for other libraries that may introspect routes. For instance, currently https://github.com/MunifTanjim/express-zod-openapi cannot work with `express-promise-router`.